### PR TITLE
Replaces NATO with ZTA in skills list

### DIFF
--- a/gitprofile.config.ts
+++ b/gitprofile.config.ts
@@ -91,7 +91,7 @@ const CONFIG = {
     'TypeScript',
     'Web4',
     'CyberSec',
-    'NATO'
+    'ZTA'
   ],
   experiences: [
     {


### PR DESCRIPTION
Updates the skills array in the configuration file, replacing 'NATO' with 'ZTA'. This change aligns the displayed skills with current practices.